### PR TITLE
Improve scripts in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,12 @@
     "friendsofphp/php-cs-fixer": "^2.16"
   },
   "scripts": {
-    "psalm": [
-      "./vendor/bin/psalm --show-info=false"
+    "check": [
+      "@cs-check",
+      "@static"
     ],
-    "cs": [
-      "./vendor/bin/php-cs-fixer fix --allow-risky yes"
-    ]
+    "static": "psalm --show-info=false",
+    "cs-check": "php-cs-fixer --allow-risky yes",
+    "cs-fix": "php-cs-fixer fix --allow-risky yes"
   }
 }


### PR DESCRIPTION
- One line commands doesn't need array
- Composer look for php commands in ./vendor/bin automatically
- Add single command to check for code style and run static analysis at once (you can reference with @ + script name)